### PR TITLE
docs: import nuxt composables from #imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ Create a file in your plugins folder:
 
 ```ts
 // plugins/qui.ts
-import { defineNuxtPlugin } from '#app';
+import { defineNuxtPlugin } from '#imports';
 import Qui from '@qvant/qui-max';
 
 export default defineNuxtPlugin(nuxtApp => {

--- a/stories/intro.stories.mdx
+++ b/stories/intro.stories.mdx
@@ -158,7 +158,7 @@ Create a file in your plugins folder:
 
 ```ts
 // plugins/qui.ts
-import { defineNuxtPlugin } from '#app';
+import { defineNuxtPlugin } from '#imports';
 import Qui from '@qvant/qui-max';
 
 export default defineNuxtPlugin(nuxtApp => {

--- a/vuepress-docs/docs/guide/getting-started.md
+++ b/vuepress-docs/docs/guide/getting-started.md
@@ -106,7 +106,7 @@ Create a file in your plugins folder:
 
 ```ts
 // plugins/qui.ts
-import { defineNuxtPlugin } from '#app';
+import { defineNuxtPlugin } from '#imports';
 import Qui from '@qvant/qui-max';
 
 export default defineNuxtPlugin(nuxtApp => {


### PR DESCRIPTION
This is a DX improvement when developing - we can avoid loading the entire barrel file at `#app` by using the new granular imports merged in https://github.com/nuxt/nuxt/pull/23951.